### PR TITLE
chore: fix check-operator-sdk-release.yml

### DIFF
--- a/.github/workflows/check-operator-sdk-release.yml
+++ b/.github/workflows/check-operator-sdk-release.yml
@@ -12,7 +12,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          latest_version=$(curl --silent "https://api.github.com/repos/operator-framework/operator-sdk/releases" | jq -r '.[].tag_name' | head -10 | sort -r | head -1)
+          latest_version=$(curl --silent "https://api.github.com/repos/operator-framework/operator-sdk/releases" | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | test("^v[0-9]+.[0-9]+.0$") ) | .tag_name' | head -1)
           current_version=$(grep operator-sdk README.md | sed 's/.*\(v[0-9]\+.[0-9]\+.[0-9]\+\).*/\1/')
           current_minor_version=$(grep operator-sdk README.md | sed 's/.*\(v[0-9]\+.[0-9]\+\).*/\1/')
           latest_minor_version=$(echo ${latest_version} | sed 's/.*\(v[0-9]\+.[0-9]\+\).*/\1/')


### PR DESCRIPTION
```
curl --silent "https://api.github.com/repos/operator-framework/operator-sdk/releases" | jq -r '. | sort_by(.published_at) | reverse | .[] | select(.tag_name | test("^v[0-9]+.[0-9]+.0$") ) | .tag_name'
v1.28.0
v1.27.0
v1.26.0
v1.25.0
v1.24.0
v1.23.0
v1.22.0
v1.21.0
v1.20.0
v1.19.0
v1.18.0
v1.17.0
v1.16.0
v1.15.0
v1.14.0
v1.13.0
v1.12.0
```